### PR TITLE
Export player names in CSV

### DIFF
--- a/REFlexFunctions.lua
+++ b/REFlexFunctions.lua
@@ -102,7 +102,7 @@ function RE:GetArenaTeamCSV(databaseID, player)
 	local team = {}
 	for i=1, #RE.Database[databaseID].Players do
 		if RE.Database[databaseID].Players[i][6] == faction then
-			tinsert(team, RE.Database[databaseID].Players[i][9].."-"..RE.Database[databaseID].Players[i][16])
+			tinsert(team, RE.Database[databaseID].Players[i][9].."-"..RE.Database[databaseID].Players[i][16].."-"..RE.Database[databaseID].Players[i][1])
 		end
 	end
 	tsort(team)


### PR DESCRIPTION
I'm looking to build a tool to allow players to upload their arena match history to track and analyze arena matches played on Drustvar.com. Reflex is perfect for this but was missing the player names on the export.  I've added it attached to their Class and Spec column. Wasn't sure if this would've been better in a new column or not.

Example:
WARLOCK-Demonology-Leeka-Tichondrius, player2info, player3info

edit- the only thing I've noticed is that it doesn't provide the server name if you're on the same server.