### PR TITLE
fix: mark blitz or solo rbgs as rated

### DIFF
--- a/REFlex.lua
+++ b/REFlex.lua
@@ -22,6 +22,7 @@ local IsSoloShuffle = C_PvP.IsSoloShuffle
 local IsRatedSoloShuffle = C_PvP.IsRatedSoloShuffle
 local IsRatedArena = C_PvP.IsRatedArena
 local IsRatedBattleground = C_PvP.IsRatedBattleground
+local IsSoloRBG = C_PvP.IsSoloRBG
 local IsArenaSkirmish = IsArenaSkirmish
 local IsPlayerAtEffectiveMaxLevel = IsPlayerAtEffectiveMaxLevel
 local SetBattlefieldScoreFaction = SetBattlefieldScoreFaction
@@ -922,7 +923,7 @@ function RE:PVPEnd()
 		RE.MatchData.Map = RE.MapIDRemap[RE.MatchData.Map]
 	end
 
-	if IsRatedBattleground() or (IsRatedArena() and not IsArenaSkirmish() and not RE.MatchData.isSoloShuffle) or IsRatedSoloShuffle() then
+	if IsRatedBattleground() or IsSoloRBG() or (IsRatedArena() and not IsArenaSkirmish() and not RE.MatchData.isSoloShuffle) or IsRatedSoloShuffle() then
 		RE.MatchData.isRated = true
 	else
 		RE.MatchData.isRated = false

--- a/REFlex.toc
+++ b/REFlex.toc
@@ -1,7 +1,7 @@
 ## Interface: 110002
 ## Title: |cFF74D06CRE|rFlex
 ## Notes: Collect statistics of played arena matches and battlegrounds.
-## Version: 3.3.16
+## Version: 3.3.17
 ## Author: AcidWeb
 ## SavedVariablesPerCharacter: REFlexSettings, REFlexDatabase, REFlexHonorDatabase
 ## AddonCompartmentFunc: REFlex_CompartmentOnClick


### PR DESCRIPTION
This adds support for the new solo rbg or battleground blitz mode. It sets the match as rated so it shows up properly in reflex.